### PR TITLE
fix: jetty9にあたCountDownLatchの仕組みを再導入

### DIFF
--- a/src/main/java/nablarch/fw/web/httpserver/HttpServerJetty12.java
+++ b/src/main/java/nablarch/fw/web/httpserver/HttpServerJetty12.java
@@ -8,11 +8,14 @@ import java.util.ArrayList;
 import java.util.EnumSet;
 import java.util.List;
 import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 
 import jakarta.servlet.DispatcherType;
 import jakarta.servlet.Filter;
 
 import jakarta.servlet.SessionTrackingMode;
+import nablarch.test.core.http.HttpRequestTestSupportHandler;
 import org.apache.tomcat.JarScanner;
 import org.apache.tomcat.util.scan.StandardJarScanner;
 import org.eclipse.jetty.ee10.annotations.AnnotationConfiguration;
@@ -137,9 +140,12 @@ public class HttpServerJetty12 extends HttpServer {
             ((MockHttpRequest) req).setHost("127.0.0.1");
         }
 
+        final CountDownLatch latch = new CountDownLatch(1);
+        sourceContext.setRequestScopedVar(HttpRequestTestSupportHandler.NABLARCH_JETTY_CONNECTOR_LATCH, latch);
         try {
             byte[] rawReq = req.toString().getBytes();
             ByteBuffer response = localConnector.getResponse(ByteBuffer.wrap(rawReq));
+            latch.await(10L, TimeUnit.SECONDS);
             byte[] rawRes = new byte[response.remaining()];
             response.get(rawRes);
             HttpResponse res = HttpResponse.parse(rawRes);


### PR DESCRIPTION
CIでまれにテストが落ちるので、nablarch-testing-jetty9にあったCountDownLatchを使った制御を復活させる。