### PR TITLE
タグファイル中ののuriをJakarta Standard Tag Library用のものに変更

### DIFF
--- a/src/test/resources/nablarch/fw/web/sample/app/jsp/jstl_test.jsp
+++ b/src/test/resources/nablarch/fw/web/sample/app/jsp/jstl_test.jsp
@@ -1,4 +1,4 @@
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jsch/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <html>
   <head>
     <title>Greeting Service</title>


### PR DESCRIPTION
変更前のuriが `"http://java.sun.com/jsp/jsch/core"` となっている。
これについては、以下の点から誤りであると思われる
- 上記uriを使用している箇所が[ウェブ上でヒットしない](https://www.google.com/search?q=%22jsp%2Fjsch%2Fcore%22&sca_esv=20d11f431ee94e02&rlz=1C1GCEU_jaJP853JP853&ei=WKtvZpPMKoz31e8P9byc2As&ved=0ahUKEwiT2KiC1-GGAxWMe_UHHXUeB7sQ4dUDCBA&uact=5&oq=%22jsp%2Fjsch%2Fcore%22&gs_lp=Egxnd3Mtd2l6LXNlcnAiDyJqc3AvanNjaC9jb3JlIjIIEAAYgAQYogQyCBAAGIAEGKIESPQRULEGWIIJcAF4AJABAJgBWqABrgGqAQEyuAEDyAEA-AEBmAICoAKyAZgDAIgGAZIHATKgB-gE&sclient=gws-wiz-serp)（何らかの仕様で定義されているなら検索結果に表れるはず）
- [JSch](http://www.jcraft.com/jsch/)というJava向けライブラリはあるが、SSH2の実装であり、タグライブラリとは何も関係ない

prefixが`"c"`であることも考慮すると、本来はコアライブラリ（ `"http://java.sun.com/jsp/jstl/core"` ）を指定する想定だったと考えられる。 これをふまえ、変更後のuriは `"http://jakarta.tags.core"` とした

なお、当該ファイルを削除してもテスト自体は成功した。
そのためファイル自体をなくしても問題はないと思われるものの、どのような意図でそのようなファイルを残しているか不明であるため、残置する判断とした。