### PR TITLE
Jettyを 12.0.12 にバージョンアップ

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
   </parent>
   
   <properties>
-    <jetty.version>12.0.3</jetty.version>
+    <jetty.version>12.0.12</jetty.version>
   </properties>
 
   <dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,6 @@
   </parent>
   
   <properties>
-    <ecj.version>3.5.1</ecj.version>
     <jetty.version>12.0.3</jetty.version>
   </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -74,12 +74,6 @@
     <dependency>
       <groupId>com.nablarch.framework</groupId>
       <artifactId>nablarch-testing</artifactId>
-      <exclusions>
-        <exclusion>
-          <groupId>org.eclipse.jdt.core.compiler</groupId>
-          <artifactId>ecj</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
 
     <dependency>

--- a/src/main/java/nablarch/fw/web/httpserver/HttpServerJetty12.java
+++ b/src/main/java/nablarch/fw/web/httpserver/HttpServerJetty12.java
@@ -21,12 +21,14 @@ import org.apache.tomcat.util.scan.StandardJarScanner;
 import org.eclipse.jetty.ee10.annotations.AnnotationConfiguration;
 import org.eclipse.jetty.ee10.webapp.JspConfiguration;
 import org.eclipse.jetty.ee10.webapp.WebAppConfiguration;
+import org.eclipse.jetty.ee10.servlet.SessionHandler;
+import org.eclipse.jetty.ee10.servlet.FilterHolder;
 import org.eclipse.jetty.server.Connector;
+import org.eclipse.jetty.server.HttpConfiguration;
+import org.eclipse.jetty.server.HttpConnectionFactory;
 import org.eclipse.jetty.server.LocalConnector;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.ServerConnector;
-import org.eclipse.jetty.ee10.servlet.SessionHandler;
-import org.eclipse.jetty.ee10.servlet.FilterHolder;
 import org.eclipse.jetty.util.resource.Resource;
 import org.eclipse.jetty.ee10.webapp.Configuration;
 import org.eclipse.jetty.ee10.webapp.WebAppContext;
@@ -70,7 +72,15 @@ public class HttpServerJetty12 extends HttpServer {
      */
     public HttpServerJetty12 start() {
         jetty = new Server(getPort());
-        Connector conn = new ServerConnector(jetty);
+
+        // 12.0.5 でembedded modeだけrelativeRedirectAllowed のデフォルト値が変更されている。
+        // 以前の挙動を前提にテストコードを実装していると失敗してしまうため、設定を戻す。
+        // https://github.com/jetty/jetty.project/issues/11947
+        HttpConfiguration httpConfig = new HttpConfiguration();
+        httpConfig.setRelativeRedirectAllowed(false);
+        HttpConnectionFactory httpConnectionFactory = new HttpConnectionFactory(httpConfig);
+
+        Connector conn = new ServerConnector(jetty, httpConnectionFactory);
         initialize(conn);
         try {
             jetty.start();
@@ -89,7 +99,15 @@ public class HttpServerJetty12 extends HttpServer {
      */
     public HttpServerJetty12 startLocal() {
         jetty = new Server();
-        localConnector = new LocalConnector(jetty);
+
+        // 12.0.5 でembedded modeだけrelativeRedirectAllowed のデフォルト値が変更されている。
+        // 以前の挙動を前提にテストコードを実装していると失敗してしまうため、設定を戻す。
+        // https://github.com/jetty/jetty.project/issues/11947
+        HttpConfiguration httpConfig = new HttpConfiguration();
+        httpConfig.setRelativeRedirectAllowed(false);
+        HttpConnectionFactory httpConnectionFactory = new HttpConnectionFactory(httpConfig);
+
+        localConnector = new LocalConnector(jetty, httpConnectionFactory);
         initialize(localConnector);
         try {
             jetty.start();


### PR DESCRIPTION
Jetty 12のバージョンを `12.0.12` にバージョンアップしました。

ただ、`12.0.5`からembedded modeだけ`relativeRedirectAllowed`プロパティのデフォルト値が変更されており、以前の挙動を前提にしたテストコードでは失敗してしまう状態になっていました（リダイレクト時にレスポンスヘッダに設定されるパスが相対パスになってしまう）。以前の挙動に戻しておくべきだと判断したため、設定値が以前と変わらないように修正しています。

合わせて、別対応により`nablarch-testing`から`ecj`への依存が削除されているため関連設定を削除しました。
（`nablarch-testing`が依存する`ecj`はグループID含めて古く、元々から使用していない状態だった）